### PR TITLE
Remove date parameter from cron:: there is no date parameter in the p…

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -65,7 +65,6 @@ class mirror_repos::config {
       user    => 'root',
       hour    => $mirror_repos::cron_hour,
       minute  => $mirror_repos::cron_minute,
-      date    => $mirror_repos::cron_date,
       month   => $mirror_repos::cron_month,
       weekday => $mirror_repos::cron_weekday,
       require => File['/usr/sbin/update-repos'],


### PR DESCRIPTION
…uppet stdlib cron:: resource.

Only the cron::job resource allows the date parameter.